### PR TITLE
Fix csv->typst export

### DIFF
--- a/src/mca_tools/helpers.py
+++ b/src/mca_tools/helpers.py
@@ -147,7 +147,7 @@ def calibration_helper(folder_path, bkg_file = None, **kwargs):
         else:
             formatted_p_value = (f"{p_value:.2f}")
 
-        dic.update({f"p-value(%)": formatted_p_value})
+        dic.update({f"$\"p-value\"(%)$": formatted_p_value})
 
         df = pd.DataFrame(dic, index = [0])
         df.to_csv(os.path.join(output_path, "csv", calcs_str[i] + ".csv"), index = False)

--- a/src/mca_tools/peakSelector.py
+++ b/src/mca_tools/peakSelector.py
@@ -1022,7 +1022,7 @@ class peakSelector:
         dic_df.update({"$mu$": formatted_params[4]})
         dic_df.update({"$sigma$": formatted_params[5]})
         dic_df.update({"$chi^2_r$": formatted_chi2})
-        dic_df.update({r"p-value (\%)": formatted_pvalue})
+        dic_df.update({f"$\"p-value\"$(%)": formatted_pvalue})
 
         df = pd.DataFrame(dic_df)
 


### PR DESCRIPTION
(Assuming Bash)

Compile with:
```
--input csv_calibracion="$(wildcard path/to/my/*.csv)"
```

In typst:
```typst
#let csv_cal = {
    sys.inputs.at("csv_calibracion")
        .split(" ")
        .map(x => x.trim("un-needed/path/parts"))
}

#for i in range(csv_cal.len()) {
    table(
        columns: 8,
            ..csv( csv_cal.at(i) ).at(0).map(x => eval(x)), // first row, headings
            ..csv( csv_cal.at(i) ).slice(1).flatten(), // rest
    )
}
```

Result. (obviously it should be customized further, but thats on the user)

<img width="768" height="360" alt="20260409191002_grim" src="https://github.com/user-attachments/assets/e45b31d0-4e03-4a0a-86ce-0b7c16ee91bf" />

